### PR TITLE
Update tag to be configurable via env variable.

### DIFF
--- a/tests/10-create.js
+++ b/tests/10-create.js
@@ -9,9 +9,10 @@ import {
 import {endpoints} from 'vc-test-suite-implementations';
 import {generateTestData} from './vc-generator/index.js';
 import {klona} from 'klona';
+import {tag} from './test-config.js';
 import {v4 as uuidv4} from 'uuid';
+
 // only use implementations with `Ed25519 2020` issuers.
-const tag = 'Ed25519Signature2020';
 const {match} = endpoints.filterByTag({tags: [tag], property: 'issuers'});
 const should = chai.should();
 
@@ -43,7 +44,7 @@ describe('Ed25519Signature2020 (create)', function() {
         before(async function() {
           const [issuer] = endpoints;
           verifier = implementation.verifiers.find(
-            verifier => verifier.tags.has('Ed25519Signature2020'));
+            verifier => verifier.tags.has(tag));
           const {settings: {id: issuerId, options}} = issuer;
           const body = {credential: klona(validVc), options};
           body.credential.id = `urn:uuid:${uuidv4()}`;

--- a/tests/10-create.js
+++ b/tests/10-create.js
@@ -1,5 +1,6 @@
 /*!
- * Copyright (c) 2022 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2022-2024 Digital Bazaar, Inc.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 import {bs58Decode, getPublicKeyBytes} from './helpers.js';
 import chai from 'chai';

--- a/tests/20-verify.js
+++ b/tests/20-verify.js
@@ -9,10 +9,11 @@ import {
 import {endpoints} from 'vc-test-suite-implementations';
 import {generateTestData} from './vc-generator/index.js';
 import {klona} from 'klona';
+import {tag} from './test-config.js';
 
 // only use implementations with `Ed25519 2020` verifiers.
 const {match} = endpoints.filterByTag({
-  tags: ['Ed25519Signature2020'],
+  tags: [tag],
   property: 'verifiers'
 });
 
@@ -43,7 +44,7 @@ describe('Ed25519Signature2020 (verify)', function() {
     for(const [name, {implementation}] of match) {
       describe(name, function() {
         const verifier = implementation.verifiers.find(
-          verifier => verifier.tags.has('Ed25519Signature2020'));
+          verifier => verifier.tags.has(tag));
         it('MUST verify a valid VC with an Ed25519Signature2020 proof',
           async function() {
             this.test.cell = {

--- a/tests/20-verify.js
+++ b/tests/20-verify.js
@@ -1,5 +1,6 @@
 /*!
- * Copyright (c) 2022 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2022-2024 Digital Bazaar, Inc.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 import {bs58Decode, bs58Encode} from './helpers.js';
 import {verificationFail, verificationSuccess} from './assertions.js';

--- a/tests/30-interop.js
+++ b/tests/30-interop.js
@@ -1,5 +1,6 @@
 /*!
- * Copyright (c) 2022 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2022-2024 Digital Bazaar, Inc.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 import chai from 'chai';
 import {filterByTag} from 'vc-test-suite-implementations';

--- a/tests/30-interop.js
+++ b/tests/30-interop.js
@@ -5,10 +5,10 @@ import chai from 'chai';
 import {filterByTag} from 'vc-test-suite-implementations';
 import {generateTestData} from './vc-generator/index.js';
 import {klona} from 'klona';
+import {tag} from './test-config.js';
 import {v4 as uuidv4} from 'uuid';
 
 const should = chai.should();
-const tag = 'Ed25519Signature2020';
 
 // only use implementations with `Ed25519 2020` issuers.
 const {
@@ -36,7 +36,7 @@ describe('Ed25519Signature2020 (interop)', function() {
     let issuerError;
     before(async function() {
       const issuer = issuers.find(issuer =>
-        issuer.tags.has('Ed25519Signature2020'));
+        issuer.tags.has(tag));
       const {settings: {id: issuerId, options}} = issuer;
       const body = {credential: klona(validVc), options};
       body.credential.id = `urn:uuid:${uuidv4()}`;

--- a/tests/LICENSE.md
+++ b/tests/LICENSE.md
@@ -1,0 +1,28 @@
+BSD 3-Clause License
+
+Copyright (c) 2024, W3C, Inc.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/tests/assertions.js
+++ b/tests/assertions.js
@@ -1,5 +1,6 @@
 /*!
- * Copyright (c) 2022 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2022-2024 Digital Bazaar, Inc.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 import chai from 'chai';
 

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1,5 +1,6 @@
 /*!
- * Copyright (c) 2022 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2022-2024 Digital Bazaar, Inc.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 import * as didKey from '@digitalbazaar/did-method-key';
 import {IdDecoder, IdEncoder} from 'bnid';

--- a/tests/test-config.js
+++ b/tests/test-config.js
@@ -1,0 +1,6 @@
+/*!
+ * Copyright (c) 2022-2024 Digital Bazaar, Inc.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+export const tag = process.env.TAG || 'Ed25519Signature2020';

--- a/tests/vc-generator/TestEd25519Signature2020.js
+++ b/tests/vc-generator/TestEd25519Signature2020.js
@@ -1,5 +1,6 @@
 /*!
- * Copyright (c) 2022 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2022-2024 Digital Bazaar, Inc.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 import * as base58btc from 'base58-universal';
 import {

--- a/tests/vc-generator/TestLinkedDataSignature.js
+++ b/tests/vc-generator/TestLinkedDataSignature.js
@@ -1,5 +1,6 @@
 /*!
- * Copyright (c) 2022 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2022-2024 Digital Bazaar, Inc.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 import {api} from './util.js';
 import {createRequire} from 'node:module';

--- a/tests/vc-generator/contexts.js
+++ b/tests/vc-generator/contexts.js
@@ -1,5 +1,6 @@
 /*!
- * Copyright (c) 2022 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2022-2024 Digital Bazaar, Inc.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 // import {contexts} from '@digitalbazaar/vc';
 import credentialsCtx from 'credentials-context';

--- a/tests/vc-generator/documentLoader.js
+++ b/tests/vc-generator/documentLoader.js
@@ -1,5 +1,6 @@
 /*!
- * Copyright (c) 2022 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2022-2024 Digital Bazaar, Inc.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 import {contextMap} from './contexts.js';
 import {JsonLdDocumentLoader} from 'jsonld-document-loader';

--- a/tests/vc-generator/hashDigest.js
+++ b/tests/vc-generator/hashDigest.js
@@ -1,5 +1,6 @@
 /*!
- * Copyright (c) 2022 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2022-2024 Digital Bazaar, Inc.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 import crypto from 'crypto';
 

--- a/tests/vc-generator/helpers.js
+++ b/tests/vc-generator/helpers.js
@@ -1,5 +1,6 @@
 /*!
- * Copyright (c) 2022 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2022-2024 Digital Bazaar, Inc.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 import * as didKey from '@digitalbazaar/did-method-key';
 import {decodeSecretKeySeed} from 'bnid';

--- a/tests/vc-generator/index.js
+++ b/tests/vc-generator/index.js
@@ -1,5 +1,6 @@
 /*!
- * Copyright (c) 2022 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2022-2024 Digital Bazaar, Inc.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 import * as base58btc from 'base58-universal';
 import * as vc from '@digitalbazaar/vc';

--- a/tests/vc-generator/util.js
+++ b/tests/vc-generator/util.js
@@ -1,5 +1,6 @@
 /*!
- * Copyright (c) 2022 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2022-2024 Digital Bazaar, Inc.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 export const api = {};
 


### PR DESCRIPTION
Not sure if this is what we want to do, but if we make the tag configurable then it will allow testers to specify the tag they want to use to run only the localhost implementations otherwise they'll have to manually update the tags in multiple places See - https://github.com/w3c/vc-test-suite-implementations/issues/14#issuecomment-1889297203